### PR TITLE
fix deprecation warnings in runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,14 @@
 using AMD
-using Base.Test
+if VERSION < v"0.7.0-DEV.2005"
+  using Base.Test
+else
+  using Test
+end
+if VERSION < v"0.7.0-DEV.3389"
+  const SparseArrays = Base.SparseArrays
+else
+  using SparseArrays
+end
 
 _Clong = Base.Sys.WORD_SIZE == 32 ? Clong : Clonglong
 for n in [10, 20, 30]


### PR DESCRIPTION
Hi. I just fixed some deprecation warnings in `runtests.jl` using Julia 0.7.0 (and perhaps 1.0).
