### PR TITLE
Add citation.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Montoison
+    given-names: Alexis
+    orcid: https://orcid.org/0000-0002-3403-5450
+  - family-names: Orban
+    given-names: Dominique
+    orcid: https://orcid.org/0000-0002-8017-7687
+  - family-names: Siqueira
+    given-names: Abel S.
+    orcid: https://orcid.org/0000-0003-4451-281X
+  - name: "contributors"
+title: "AMD.jl: A Julia interface to the AMD library of Amestoy, Davis and Duff"
+identifiers:
+  - description: "The concept DOI of the work."
+    type: doi
+    value: 10.5281/zenodo.3381898
+  - description: "The versioned DOI for version 0.4.0 of the work."
+    type: doi
+    value: 10.5281/zenodo.3783808
+doi: 10.5281/zenodo.3381898
+date-released: "2020-05-03"
+license: Mozilla Public License 2.0
+repository-code: "https://github.com/JuliaSmoothOptimizers/AMD.jl"


### PR DESCRIPTION
This would produce a bibtex of the form
```
@software{Orban_AMD.jl_A_Julia_2021,
author = {Orban, Dominique and {contributors}},
doi = {10.5281/zenodo.3381898},
license = {Mozilla Public License 2.0},
month = {5},
title = {{AMD.jl: A Julia interface to the AMD library of Amestoy, Davis and Duff}},
url = {https://github.com/JuliaSmoothOptimizers/AMD.jl},
year = {2020}
}
```