### PR TITLE
use push_preview = true in deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,4 +13,8 @@ makedocs(
   pages = Any["Home" => "index.md", "Tutorial" => "tutorial.md", "Reference" => "reference.md"],
 )
 
-deploydocs(repo = "github.com/JuliaSmoothOptimizers/AMD.jl.git", devbranch = "main")
+deploydocs(
+  repo = "github.com/JuliaSmoothOptimizers/AMD.jl.git",
+  push_preview = true,
+  devbranch = "main",
+)


### PR DESCRIPTION
With this change, a new workflow named "documenter/deploy" appears in the list of checks when the docs have finished building.
Clicking on "details" takes you to the docs resulting from the pull request.